### PR TITLE
Unpin properties version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'pypng',
         'requests',
         'six',
-        'properties==0.4.0',
+        'properties>=0.4.0',
         'vectormath',
     ],
     author='Seequent',


### PR DESCRIPTION
The steno3d library is compatible with all versions of properties after 0.4.0.